### PR TITLE
Added functionality for signed and encrypted cookies

### DIFF
--- a/lib/authenticate/configuration.rb
+++ b/lib/authenticate/configuration.rb
@@ -64,9 +64,6 @@ module Authenticate
     # When set to `true`, Authenticate will use Rails 'signed cookie' mechanism to
     # prevent tampering with cookie value.
     #
-    # You should have `secret_key_base` set for your environment in `config/secrets.yml`
-    # or Authenticate will fallback to default mechanism.
-    #
     # For more, see [ActionDispatch::Cookies documentation](http://api.rubyonrails.org/classes/ActionDispatch/Cookies.html).
     # @return [Boolean]
     attr_accessor :signed_cookie
@@ -84,6 +81,9 @@ module Authenticate
     #
     # You should set this value to true in live environments where you can not use
     # [#secure_cookie] (e.g. non-https connections).
+    #
+    # If set to `true` and `secret_key_base` in `config/secrets.yml` is not set,
+    # Authenticate will fallback to 'signed cookie' mechanism.
     #
     # For more, see [ActionDispatch::Cookies documentation](http://api.rubyonrails.org/classes/ActionDispatch/Cookies.html).
     # @return [Boolean]

--- a/lib/authenticate/configuration.rb
+++ b/lib/authenticate/configuration.rb
@@ -57,6 +57,38 @@ module Authenticate
     # @return [String]
     attr_accessor :cookie_path
 
+    # Controls whether cookie should be signed with your app's secret.
+    #
+    # Defaults to `false`.
+    #
+    # When set to `true`, Authenticate will use Rails 'signed cookie' mechanism to
+    # prevent tampering with cookie value.
+    #
+    # You should have `secret_key_base` set for your environment in `config/secrets.yml`
+    # or Authenticate will fallback to default mechanism.
+    #
+    # For more, see [ActionDispatch::Cookies documentation](http://api.rubyonrails.org/classes/ActionDispatch/Cookies.html).
+    # @return [Boolean]
+    attr_accessor :signed_cookie
+
+    # Controls whether cookie should be encrypted.
+    #
+    # Defaults to `false`.
+    #
+    # When set to `true`, Authenticate will encrypt cookie value using Rails built-in
+    # mechanism to prevent tampering with cookie value. In addition, [#signed_cookie] option
+    # will be omitted.
+    #
+    # It differs from [#signed_cookie] in that cookie value will be encrypted before
+    # being signed.
+    #
+    # You should set this value to true in live environments where you can not use
+    # [#secure_cookie] (e.g. non-https connections).
+    #
+    # For more, see [ActionDispatch::Cookies documentation](http://api.rubyonrails.org/classes/ActionDispatch/Cookies.html).
+    # @return [Boolean]
+    attr_accessor :encrypted_cookie
+
     # Controls the secure setting on the session cookie.
     #
     # Defaults to `false`.
@@ -244,6 +276,8 @@ module Authenticate
       @cookie_expiration = -> { 1.year.from_now.utc }
       @cookie_domain = nil
       @cookie_path = '/'
+      @signed_cookie = false
+      @encrypted_cookie = false
       @secure_cookie = false
       @cookie_http_only = true
       @mailer_sender = 'reply@example.com'

--- a/lib/authenticate/session.rb
+++ b/lib/authenticate/session.rb
@@ -121,7 +121,13 @@ module Authenticate
     end
 
     def get_cookies_class
-      signed_or_encrypted? ? @cookies.signed_or_encrypted : @cookies
+      if Authenticate.configuration.encrypted_cookie
+        @cookies.encrypted
+      elsif Authenticate.configuration.signed_cookie
+        @cookies.signed
+      else
+        @cookies
+      end
     end
   end
 end

--- a/lib/authenticate/session.rb
+++ b/lib/authenticate/session.rb
@@ -14,7 +14,7 @@ module Authenticate
     def initialize(request)
       @request = request # trackable module accesses request
       @cookies = request.cookie_jar
-      @session_token = @cookies[cookie_name]
+      @session_token = session_token_cookie
       debug 'SESSION initialize: @session_token: ' + @session_token.inspect
     end
 
@@ -96,8 +96,8 @@ module Authenticate
         expires: Authenticate.configuration.cookie_expiration.call
       }
       cookie_hash[:domain] = Authenticate.configuration.cookie_domain if Authenticate.configuration.cookie_domain
-      # Consider adding an option for a signed cookie
-      @cookies[cookie_name] = cookie_hash
+
+      self.session_token_cookie = cookie_hash
     end
 
     def cookie_name
@@ -106,6 +106,30 @@ module Authenticate
 
     def load_user_from_session_token
       Authenticate.configuration.user_model_class.where(session_token: @session_token).first
+    end
+
+    def session_token_cookie
+      get_cookies_class[cookie_name]
+    end
+
+    def session_token_cookie=(value)
+      get_cookies_class[cookie_name] = value
+    end
+
+    def secret_present?
+      !!Rails.application.secrets.try(:secret_key_base)
+    end
+
+    def signed_or_encrypted?
+      Authenticate.configuration.encrypted_cookie || Authenticate.configuration.signed_cookie
+    end
+
+    def get_cookies_class
+      if signed_or_encrypted? && secret_present?
+        Authenticate.configuration.encrypted_cookie ? @cookies.encrypted : @cookies.signed
+      else
+        @cookies
+      end
     end
   end
 end

--- a/lib/authenticate/session.rb
+++ b/lib/authenticate/session.rb
@@ -116,20 +116,12 @@ module Authenticate
       get_cookies_class[cookie_name] = value
     end
 
-    def secret_present?
-      !!Rails.application.secrets.try(:secret_key_base)
-    end
-
     def signed_or_encrypted?
       Authenticate.configuration.encrypted_cookie || Authenticate.configuration.signed_cookie
     end
 
     def get_cookies_class
-      if signed_or_encrypted? && secret_present?
-        Authenticate.configuration.encrypted_cookie ? @cookies.encrypted : @cookies.signed
-      else
-        @cookies
-      end
+      signed_or_encrypted? ? @cookies.signed_or_encrypted : @cookies
     end
   end
 end

--- a/spec/dummy/config/initializers/authenticate.rb
+++ b/spec/dummy/config/initializers/authenticate.rb
@@ -5,5 +5,6 @@ Authenticate.configure do |config|
   config.bad_login_lockout_period = 10.minutes
   config.reset_password_within = 5.minutes
   config.password_length = 8..128
+  config.encrypted_cookie = true
   config.debug = true
 end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -44,7 +44,11 @@ module RequestHelpers
   # Sometimes cookie is a cookie, and sometimes it is not.
   #
   def wrap_cookie(cookie)
-    def cookie.signed_or_encrypted
+    def cookie.signed
+      self
+    end
+
+    def cookie.encrypted
       self
     end
 

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -44,11 +44,7 @@ module RequestHelpers
   # Sometimes cookie is a cookie, and sometimes it is not.
   #
   def wrap_cookie(cookie)
-    def cookie.signed
-      self
-    end
-
-    def cookie.encrypted
+    def cookie.signed_or_encrypted
       self
     end
 

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -56,8 +56,6 @@ module RequestHelpers
   end
 end
 
-
-
 RSpec.configure do |config|
   config.include RequestHelpers
 end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -32,14 +32,31 @@ module RequestHelpers
     req = double('request')
     allow(req).to receive(:params).and_return(params)
     allow(req).to receive(:remote_ip).and_return('111.111.111.111')
-    allow(req).to receive(:cookie_jar).and_return(cookies)
+    allow(req).to receive(:cookie_jar).and_return(wrap_cookie(cookies))
     req
   end
 
   def session_cookie_for(user)
     { Authenticate.configuration.cookie_name.freeze.to_sym => user.session_token }
   end
+
+  #
+  # Sometimes cookie is a cookie, and sometimes it is not.
+  #
+  def wrap_cookie(cookie)
+    def cookie.signed
+      self
+    end
+
+    def cookie.encrypted
+      self
+    end
+
+    cookie
+  end
 end
+
+
 
 RSpec.configure do |config|
   config.include RequestHelpers


### PR DESCRIPTION
Good day. I found that Authenticate doesn't support signed and encrypted cookies yet, so I decided to implement it.
I will be glad if you'll accept PR and maybe even bump gem version. Thanks.